### PR TITLE
step2

### DIFF
--- a/app/dao/account.go
+++ b/app/dao/account.go
@@ -37,3 +37,43 @@ func (r *account) FindByUsername(ctx context.Context, username string) (*object.
 
 	return entity, nil
 }
+
+// CreateAccount : ユーザ名とパスワードからアカウトを作成する
+func (r *account) CreateAccount(_ context.Context, username string, passwordHash string) (int64, error) {
+	stmt, err := r.db.Preparex("insert into account (username, password_hash) values (?, ?)")
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if closeErr := stmt.Close(); closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	var id int64
+	result, err := stmt.Exec(username, passwordHash)
+	if err != nil {
+		return 0, err
+	}
+
+	id, err = result.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// FindById : idからユーザを取得
+func (r *account) FindById(ctx context.Context, id int64) (*object.Account, error) {
+	entity := new(object.Account)
+	err := r.db.QueryRowxContext(ctx, "select * from account where id = ?", id).StructScan(entity)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("%w", err)
+	}
+
+	return entity, nil
+}

--- a/app/domain/repository/account.go
+++ b/app/domain/repository/account.go
@@ -9,5 +9,8 @@ import (
 type Account interface {
 	// Fetch account which has specified username
 	FindByUsername(ctx context.Context, username string) (*object.Account, error)
-	// TODO: Add Other APIs
+	// Create an account
+	CreateAccount(ctx context.Context, username string, passwordHash string) (int64, error)
+	// Fetch account which has specified id
+	FindById(ctx context.Context, id int64) (*object.Account, error)
 }

--- a/app/handler/accounts/create.go
+++ b/app/handler/accounts/create.go
@@ -16,7 +16,7 @@ type AddRequest struct {
 
 // Handle request for `POST /v1/accounts`
 func (h *handler) Create(w http.ResponseWriter, r *http.Request) {
-	// ctx := r.Context()
+	ctx := r.Context()
 
 	var req AddRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -31,8 +31,18 @@ func (h *handler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = h.app.Dao.Account() // domain/repository の取得
-	panic("Must Implement Account Registration")
+	a := h.app.Dao.Account() // domain/repository の取得
+	id, err := a.CreateAccount(ctx, account.Username, account.PasswordHash)
+	if err != nil {
+		httperror.InternalServerError(w, err)
+		return
+	}
+
+	account, err = a.FindById(ctx, id)
+	if err != nil {
+		httperror.InternalServerError(w, err)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(account); err != nil {


### PR DESCRIPTION
# アカウント作成APIの実装
以下のエンドポイントを実装しましょう。
- POST /v1/accounts

エンドポイントの実装には以下が必要になります。

- [x] 必要な MySQL テーブルの定義（ddl/ddl.sql)
- [x] app/domain/{repository,object}の用意
- [x] app/daoの実装
- [x] app/handlerの実装
- [x] app/handler/router.goへの登録

このエンドポイントについてはテンプレートに以下が用意されています。
- [x] MySQLテーブルの定義
- [x] アカウントオブジェクトの定義（app/domain/object）
- [x] POST /accountsのハンドラ雛形